### PR TITLE
Gear-665 Metadata & Gear-658 Config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,8 @@ RUN apt-get update -qq \
     unzip \
     pigz
 
-# Compile dcm2niix from source (version 31-March-2020 (v1.0.20200331))
-ENV DCMCOMMIT=485c387c93bbca3b29b93403dfde211c4bc39af6
+# Compile dcm2niix from source (version 2-November-2020 (v1.0.20201102))
+ENV DCMCOMMIT=081c6300d0cf47088f0873cd586c9745498f637a
 RUN curl -#L  https://github.com/rordenlab/dcm2niix/archive/$DCMCOMMIT.zip | bsdtar -xf- -C /usr/local
 WORKDIR /usr/local/dcm2niix-${DCMCOMMIT}/build
 RUN cmake -DUSE_OPENJPEG=ON -MY_DEBUG_GE=ON ../ && \

--- a/README.md
+++ b/README.md
@@ -23,16 +23,19 @@ A [Flywheel Gear](https://github.com/flywheel-io/gears/tree/master/spec) for imp
 
 #### dcm2niix
 * **anonymize_bids**: Anonymize BIDS. Options: true (default), false. 'bids_sidecar' config option must be enabled (i.e., 'y' or 'o' options).
-* **bids_sidecar**: Output BIDS sidecar in JSON format. Options are 'y'=yes (default), 'n'=no, 'o'=only (whereby no NIfTI file will be generated). Note, bids_sidecar is always invoked when running dcm2niix to be used as metadata. User configuration preference is handled after acquiring metadata.
+* **bids_sidecar**: Output BIDS sidecar in JSON format. Options are 'y'=yes, 'n'=no (default), 'o'=only (whereby no NIfTI file will be generated). Note, bids_sidecar is always invoked when running dcm2niix to be used as metadata. User configuration preference is handled after acquiring metadata.
+*  **comment**: If non-empty, store comment as NIfTI aux_file. Options: non-empty string, 24 characters maximum. Note: The 24 character comment is placed in (1) all NIfTI output files in the aux_file variable. You can use fslhdr to access the NIfTI header data and see this comment; and (2) all JSON files (i.e., BIDS sidecars), which means the comment is stored as metadata for all associated output files and would be included in the **bids_sidecar** file, if invoked.
 * **compress_nifti**: Compress output NIfTI file. Options: 'y'=yes (default), 'n'=no, '3'=no,3D. If option '3' is chosen, the filename flag will be set to '-f %p_%s' to prevent overwriting files.
 * **compression_level**: Set the gz compression level. Options: 1 (fastest) to 9 (smallest), 6 (default).
-* **convert_only_series**: Selectively convert by series number - can be used up to 16 times. Options: 'all' (default), space-separated list of series numbers (e.g., '2 12 20'). WARNING: Expert Option. We trust that if you have selected this option you know what you are asking for.
+* **convert_only_series**: Selectively convert by series number - can be used up to 16 times. Options: 'all' (default), space-separated list of series numbers (e.g., `2 12 20`). WARNING: Expert Option. We trust that if you have selected this option you know what you are asking for.
 * **crop**: Crop 3D T1 images. Options: true, false (default).
-* **filename**: Output filename template (%a=antenna (coil) number, %c=comments, %d=description, %e=echo number, %f=folder name, %i=ID of patient, %j=seriesInstanceUID, %k=studyInstanceUID, %m=manufacturer, %n=name of patient, %p=protocol, %s=series number, %t=time, %u=acquisition number, %v=vendor, %x=study ID; %z=sequence name). '%f' (default).
+*  **dcm2niix_verbose**: Whether to include verbose output from dcm2niix call. Options: true, false (default).
+* **filename**: Output filename template. Options: %a=antenna (coil) name, %b=basename, %c=comments, %d=series description, %e=echo number, %f=folder name, %i=ID of patient, %j=seriesInstanceUID, %k=studyInstanceUID, %m=manufacturer, %n=name of patient, %o=mediaObjectInstanceUID, %p=protocol, %r=instance number, %s=series number, %t=time, %u=acquisition number, %v=vendor, %x=study ID, %z=sequence name tag(0018,0024), %q sequence name tag(0018,1020). Defaults: dcm2niix tool `%f_%p_%t_%s` and dcm2niix Gear `%f`. Tip: A more informative filename can be useful for downstream BIDS curation by simply accessing relevant information in the extracted filename. For example, including echo number by including or protocol.
 * **ignore_derived**: Ignore derived, localizer, and 2D images. Options: true, false (default).
 * **ignore_errors**: Ignore dcm2niix errors and exit status, and preserve outputs. Options: true, false (default). By default, when dcm2niix exits non-zero, outputs are not preserved. WARNING: Expert Option. We trust that if you have selected this option you know what you are asking for.
-* **lossless_scaling**: Losslessly scale 16-bit integers to use dynamic range. Options: true, false (default).
+* **lossless_scaling**: Losslessly scale 16-bit integers to use dynamic range. Options: 'y'=scale, 'n'=no, but unit16->int16 (default), 'o'=original.
 * **merge2d**: Merge 2D slices from same series regardless of study time, echo, coil, orientation, etc. Options: true, false (default).
+* **output_nrrd** : Export as NRRD instead of NIfTI. Options: true, false (default).
 * **philips_scaling**: Philips precise float (not display) scaling. Options: true (default), false.
 * **single_file_mode**: Single file mode, do not convert other images in folder. Options: true, false (default).
 * **text_notes_private**: Text notes including private patient details. Options: true, false (default).
@@ -47,3 +50,99 @@ A [Flywheel Gear](https://github.com/flywheel-io/gears/tree/master/spec) for imp
 * **coil_combine**: For sequences with individual coil data, saved as individual volumes, this option will save a NIfTI file with ONLY the combined coil data (i.e., the last volume). Options: true, false (default). WARNING: Expert Option. We make no effort to check for independent coil data; we trust that you know what you are asking for if you have selected this option.
 * **decompress_dicoms**: Decompress DICOM files before conversion. This will perform decompression using gdcmconv and then perform the conversion using dcm2niix. Options: true, false (default).
 * **remove_incomplete_volumes**: Remove incomplete trailing volumes for 4D scans aborted mid-acquisition before dcm2niix conversion. Options: true, false (default).
+
+#### Metadata
+
+The dcm2niix tool extracts DICOM tags and collates these into a JSON file (i.e., the BIDS sidecar). What is extracted depends on the input data. If present, the following DICOM tags are extracted via the dcm2niix tool and applied as metadata to the output files of the dcm2niix Gear:
+
+	AcquisitionMatrixPE
+	AcquisitionNumber
+	AcquisitionTime
+	BaseResolution
+	BodyPartExamined
+	CoilString
+	ConversionSoftware
+	ConversionSoftwareVersion
+	DeviceSerialNumber
+	EchoTime
+	EchoTrainLength
+	EffectiveEchoSpacing
+	EstimatedEffectiveEchoSpacing
+	EstimatedTotalReadoutTime
+	FlipAngle
+	FrameTimesStart
+	ImageComments
+	ImageOrientationPatientDICOM
+	ImageType
+	ImagingFrequency
+	InPlanePhaseEncodingDirectionDICOM
+	InstitutionAddress
+	InstitutionalDepartmentName
+	InstitutionName
+	InternalPulseSequenceName
+	MagneticFieldStrength
+	Manufacturer
+	ManufacturersModelName
+	Modality
+	MRAcquisitionType
+	ParallelReductionFactorInPlane
+	ParallelReductionOutOfPlane
+	PartialFourier
+	PatientPosition
+	PercentPhaseFOV
+	PercentSampling
+	PhaseEncodingAxis
+	PhaseEncodingDirection
+	PhaseEncodingPolarityGE
+	PhaseEncodingSteps
+	PhaseResolution
+	PhilipsRescaleIntercept
+	PhilipsRescaleSlope
+	PhilipsRWVIntercept
+	PhilipsRWVSlope
+	PixelBandwidth
+	ProcedureStepDescription
+	ProtocolName
+	PulseSequenceDetails
+	ReceiveCoilName
+	ReconMatrixPE
+	RepetitionTime
+	SAR
+	ScanningSequence
+	ScanOptions
+	SequenceName
+	SequenceVariant
+	SeriesDescription
+	SeriesNumber
+	ShimSetting
+	SliceThickness
+	SliceTiming
+	SoftwareVersions
+	SpacingBetweenSlices
+	StationName
+	TotalReadoutTime
+	TxRefAmp
+	UsePhilipsFloatNotDisplayScaling
+	WaterFatShift
+
+If the Gear inputs are DICOMs, additional metadata is captured. If present, the following DICOM tags are extracted using [Pydicom](https://pydicom.github.io/) and applied as metadata to the output files of the dcm2niix Gear:
+
+	AcquisitionDuration, tag(0018,9073)
+	AcquisitionMatrix
+	Columns
+	InPlanePhaseEncodingDirection
+	PercentPhaseFieldOfView
+	PercentSampling
+	PixelSpacing
+	PrepulseDelay, tag(2001,101B)
+	PrepulseType, tag(2001,101C)
+	Rows
+	ScanningTechnique, tag(2001,1020)
+	ScanType, tag(2005,10A1)
+	SliceOrientation, tag(2001,100B)
+	SpacingBetweenSlices
+	NumberOfEchos, tag(2001,1014)
+	NumberOfSlices, tag(2001,1018)
+	NumberOfTemporalPositions
+
+All metadata applied to the output files from the dcm2niix Gear are extracted from the raw DICOM tags. As such, the units of measurement remain consistent with the DICOM standard. To find more information on DICOM, take a look at [NiBabel](https://nipy.org/nibabel/index.html)'s very useful [Introduction to DICOM](https://nipy.org/nibabel/dicom/dicom_intro.html).

--- a/dcm2niix/dcm2niix_run.py
+++ b/dcm2niix/dcm2niix_run.py
@@ -78,6 +78,7 @@ def convert_directory(
 
         converter = Dcm2niix()
         log.info(f"Starting dcm2niix {converter.version}")
+        log.info(f"Submitting {len(os.listdir(source_dir))} DICOMs.")
 
         converter.inputs.source_dir = source_dir
         converter.inputs.output_dir = output_dir

--- a/dcm2niix/dcm2niix_run.py
+++ b/dcm2niix/dcm2niix_run.py
@@ -16,18 +16,21 @@ def convert_directory(
     output_dir,
     anonymize_bids=True,
     bids_sidecar="y",
+    comment="",
     compress_nifti="y",
     compression_level=6,
     convert_only_series="all",
     crop=False,
-    filename="%f",
+    filename="%f_%p_%t_%s",
     ignore_derived=False,
     ignore_errors=False,
     lossless_scaling=False,
     merge2d=False,
+    output_nrrd=False,
     philips_scaling=True,
     single_file_mode=False,
     text_notes_private=False,
+    verbose=False,
 ):
     """Run dcm2niix.
 
@@ -39,9 +42,11 @@ def convert_directory(
         anonymize_bids (bool): If true, anonymize sidecar.
         bids_sidecar (str): Output sidecar; 'y'=yes, 'n'=no, 'o'=only
             (whereby no NIfTI file will be generated).
-        compress_nifti (str): Compress output NIfTI file; 'y'=yes, 'n'=no, '3'=no,3D.
-            If option '3' is chosen, the filename flag will be set to '-f %p_%s'
-            to prevent overwriting files.
+        comment (str): If non-empty, store comment as NIfTI aux_file
+            (up to 24 characters).
+        compress_nifti (str): Compress output NIfTI file; 'y'=yes, 'i'=internal,
+            'n'=no, '3'=no,3D. If option '3' is chosen, the filename flag will
+            be set to '-f %p_%s' to prevent overwriting files.
         compression_level (int): Set the gz compression level: 1 (fastest) to
             9 (smallest).
         convert_only_series (str): Space-separated list of series numbers to convert or
@@ -51,14 +56,18 @@ def convert_directory(
         ignore_derived (bool): If true, ignore derived, localizer, and 2D images.
         ignore_errors (bool): If true, ignore dcm2niix errors and exit status,
             and preserve outputs.
-        lossless_scaling (bool): If true, losslessly scale 16-bit integers
-            to use dynamic range.
-        merge2d (bool): If true, merge 2D slices from same series.
+        lossless_scaling (str): Losslessly scale 16-bit integers to use dynamic
+            range. Options: 'y'=scale, 'n'=no, but unit16->int16 (default),
+            'o'=original.",
+        merge2d (bool): If true, merge 2D slices from same series
+            regardless of echo, exposure, etc.
+        output_nrrd (bool): If true, export as NRRD instead of NIfTI.
         philips_scaling (bool): If true, Philips precise float (not display) scaling.
         single_file_mode (bool): If true, single file mode, do not convert other
             images in folder.
         text_notes_private (bool): If true, retain text notes including
             private patient details.
+        verbose (bool): If true, verbose output from dcm2niix call.
 
     Returns:
         output (nipype.interfaces.base.support.InterfaceResult): The dcm2niix
@@ -73,7 +82,7 @@ def convert_directory(
         converter.inputs.source_dir = source_dir
         converter.inputs.output_dir = output_dir
 
-        # dcm2niix command configurations for bids sidecar generation and anonymization
+        # dcm2niix command configurations for: anonymize_bids, bids_sidecar
         if bids_sidecar == "o":
             converter.inputs.bids_format = True
             converter.inputs.anon_bids = anonymize_bids
@@ -84,17 +93,27 @@ def convert_directory(
             log.info("The BIDS sidecar file will not be generated.")
             converter.inputs.bids_format = False
 
-        # dcm2niix command configurations for filename and compression
-        if compress_nifti == "3":
+        # dcm2niix command configurations for: comment
+        if comment and (len(comment) < 25):
+            converter.inputs.comment = comment
+
+        # dcm2niix command configurations for: compress nifti
+        if str(compress_nifti) == "3":
             log.info(
                 "Outputs will be saved as uncompressed 3D volumes. \
                        \nFilename will be set to %p_%s to prevent overwritting files."
             )
             filename = "%p_%s"
 
-        converter.inputs.compress = compress_nifti
+        if str(compress_nifti) in ["y", "i", "n", "3"]:
+            converter.inputs.compress = str(compress_nifti)
 
-        if (compression_level > 0) and (compression_level < 10):
+        # dcm2niix command configurations for: compression_level
+        if (
+            (compression_level > 0)
+            and (compression_level < 10)
+            and isinstance(compression_level, int)
+        ):
             converter.inputs.compression = compression_level
         else:
             log.error(
@@ -102,19 +121,7 @@ def convert_directory(
             )
             os.sys.exit(1)
 
-        converter.inputs.out_filename = filename
-
-        # Additional dcm2niix command configurations
-        converter.inputs.crop = crop
-        converter.inputs.has_private = text_notes_private
-        converter.inputs.ignore_deriv = ignore_derived
-        converter.inputs.merge_imgs = merge2d
-        converter.inputs.philips_float = philips_scaling
-        converter.inputs.single_file = single_file_mode
-
-        if lossless_scaling:
-            converter.inputs.args = "-l y"
-
+        # dcm2niix command configurations for: convert_only_series
         if convert_only_series != "all":
             log.warning(
                 "Expert Option (convert_only_series). "
@@ -125,6 +132,37 @@ def convert_directory(
 
             # See: https://www.nitrc.org/forum/forum.php?thread_id=11134&forum_id=4703
             converter.inputs.series_numbers = convert_only_series
+
+        # dcm2niix command configurations for: crop
+        converter.inputs.crop = crop
+
+        # dcm2niix command configurations for: filename
+        converter.inputs.out_filename = filename.replace(" ", "_")
+
+        # dcm2niix command configurations for: ignore_derived
+        converter.inputs.ignore_deriv = ignore_derived
+
+        # dcm2niix command configurations for: lossless_scaling
+        if lossless_scaling in ["y", "n", "o"]:
+            converter.inputs.args = f"-l {lossless_scaling}"
+
+        # dcm2niix command configurations for: merge2d
+        converter.inputs.merge_imgs = merge2d
+
+        # dcm2niix command configurations for: output_nrrd
+        converter.inputs.to_nrrd = output_nrrd
+
+        # dcm2niix command configurations for: philips_scaling
+        converter.inputs.philips_float = philips_scaling
+
+        # dcm2niix command configurations for: single_file_mode
+        converter.inputs.single_file = single_file_mode
+
+        # dcm2niix command configurations for: text_notes_private
+        converter.inputs.has_private = text_notes_private
+
+        # dcm2niix command configurations for: verbose
+        converter.inputs.verbose = verbose
 
         # Log the dcm2niix command configuration and run
         log.info(f"Command to be executed: \n\n{converter.cmdline}\n")
@@ -144,6 +182,7 @@ def convert_directory(
         log.exception(e, exc_info=False)
         output = None
 
+        # dcm2niix command configurations for: ignore_errors
         if not ignore_errors:
             os.sys.exit(1)
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,17 +2,17 @@
   "name": "dcm2niix",
   "label": "DICOM to NIfTI conversion using dcm2niix with an optional implementation of PyDeface.",
   "description": "Implementation of Chris Rorden's dcm2niix for converting DICOM to NIfTI, with an optional implementation of Poldrack Lab's PyDeface to remove facial structures from NIfTI.",
-  "version": "1.1.0_1.0.20201102_dev1",
+  "version": "1.1.0_1.0.20201102",
   "author": "Flywheel",
   "maintainer": "Flywheel <support@flywheel.io>",
-  "url": "https://github.com/rordenlab/dcm2niix & https://github.com/poldracklab/pydeface",
+  "url": "https://github.com/rordenlab/dcm2niix",
   "source": "https://github.com/flywheel-apps/dcm2niix",
   "cite": "dcm2niix doi: 10.1016/j.jneumeth.2016.03.001 & PyDeface doi: 10.5281/zenodo.3524401",
   "license": "Other",
   "custom": {
        "gear-builder": {
            "category": "converter",
-           "image": "flywheel/dcm2niix:1.1.0_1.0.20201102_dev1"
+           "image": "flywheel/dcm2niix:1.1.0_1.0.20201102"
       },
       "flywheel": {
           "suite": "Conversion"

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "dcm2niix",
   "label": "DICOM to NIfTI conversion using dcm2niix with an optional implementation of PyDeface.",
   "description": "Implementation of Chris Rorden's dcm2niix for converting DICOM to NIfTI, with an optional implementation of Poldrack Lab's PyDeface to remove facial structures from NIfTI.",
-  "version": "1.0.0_1.0.20200331",
+  "version": "1.1.0_1.0.20201102_dev0",
   "author": "Flywheel",
   "maintainer": "Flywheel <support@flywheel.io>",
   "url": "https://github.com/rordenlab/dcm2niix & https://github.com/poldracklab/pydeface",
@@ -12,7 +12,7 @@
   "custom": {
        "gear-builder": {
            "category": "converter",
-           "image": "flywheel/dcm2niix:1.0.0_1.0.20200331"
+           "image": "flywheel/dcm2niix:1.1.0_1.0.20201102_dev0"
       },
       "flywheel": {
           "suite": "Conversion"
@@ -92,12 +92,18 @@
           "type": "boolean",
           "default": false
       },
+      "comment": {
+          "description": "If non-empty, store comment as NIfTI aux_file. Options: non-empty string, 24 characters maximum.",
+          "type": "str",
+          "default": ""
+      },
       "compress_nifti": {
-          "description": "Compress output NIfTI file. Options: 'y'=yes (default), 'n'=no, '3'=no,3D. If option '3' is chosen, the filename flag will be set to '-f %p_%s' to prevent overwriting files.",
+          "description": "Compress output NIfTI file. Options: 'y'=yes (default), 'i'=internal, 'n'=no, '3'=no,3D. If option '3' is chosen, the filename flag will be set to '-f %p_%s' to prevent overwriting files.",
           "type": "string",
           "default": "y",
           "enum": [
               "y",
+              "i",
               "n",
               "3"
           ]
@@ -125,7 +131,7 @@
           "default": false
       },
       "filename": {
-          "description": "Output filename template (%a=antenna (coil) number, %c=comments, %d=description, %e=echo number, %f=folder name, %i=ID of patient, %j=seriesInstanceUID, %k=studyInstanceUID, %m=manufacturer, %n=name of patient, %p=protocol, %s=series number, %t=time, %u=acquisition number, %v=vendor, %x=study ID; %z=sequence name). '%f' (default).",
+          "description": "Output filename template. Options: %a=antenna (coil) number, %c=comments, %d=description, %e=echo number, %f=folder name, %i=ID of patient, %j=seriesInstanceUID, %k=studyInstanceUID, %m=manufacturer, %n=name of patient, %p=protocol, %s=series number, %t=time, %u=acquisition number, %v=vendor, %x=study ID, %z=sequence name. Can combine any of the options into a phrase (e.g., '%f_%p_%t_%s'). '%f' (default).",
           "type": "string",
           "default": "%f"
       },
@@ -140,12 +146,22 @@
           "default": false
       },
       "lossless_scaling": {
-          "description": "Losslessly scale 16-bit integers to use dynamic range. Options: true, false (default).",
-          "type": "boolean",
-          "default": false
+          "description": "Losslessly scale 16-bit integers to use dynamic range. Options: 'y'=scale, 'n'=no, but unit16->int16 (default), 'o'=original.",
+          "type": "string",
+          "default": "n",
+          "enum": [
+              "y",
+              "n",
+              "o"
+          ]
       },
       "merge2d": {
           "description": "Merge 2D slices from the same series regardless of study time, echo, coil, orientation, etc. Options: true, false (default).",
+          "type": "boolean",
+          "default": false
+      },
+      "output_nrrd": {
+          "description": "Export as NRRD instead of NIfTI. Options: true, false (default).",
           "type": "boolean",
           "default": false
       },
@@ -195,6 +211,11 @@
       },
       "text_notes_private": {
           "description": "Text notes including private patient details. Options: true, false (default).",
+          "type": "boolean",
+          "default": false
+      },
+      "verbose": {
+          "description": "Whether to include verbose output from dcm2niix call. Options: true, false (default).",
           "type": "boolean",
           "default": false
       }

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "dcm2niix",
   "label": "DICOM to NIfTI conversion using dcm2niix with an optional implementation of PyDeface.",
   "description": "Implementation of Chris Rorden's dcm2niix for converting DICOM to NIfTI, with an optional implementation of Poldrack Lab's PyDeface to remove facial structures from NIfTI.",
-  "version": "1.1.0_1.0.20201102_dev0",
+  "version": "1.1.0_1.0.20201102_dev1",
   "author": "Flywheel",
   "maintainer": "Flywheel <support@flywheel.io>",
   "url": "https://github.com/rordenlab/dcm2niix & https://github.com/poldracklab/pydeface",
@@ -12,7 +12,7 @@
   "custom": {
        "gear-builder": {
            "category": "converter",
-           "image": "flywheel/dcm2niix:1.1.0_1.0.20201102_dev0"
+           "image": "flywheel/dcm2niix:1.1.0_1.0.20201102_dev1"
       },
       "flywheel": {
           "suite": "Conversion"
@@ -94,7 +94,7 @@
       },
       "comment": {
           "description": "If non-empty, store comment as NIfTI aux_file. Options: non-empty string, 24 characters maximum.",
-          "type": "str",
+          "type": "string",
           "default": ""
       },
       "compress_nifti": {
@@ -125,13 +125,18 @@
           "type": "boolean",
           "default": false
       },
+      "dcm2niix_verbose": {
+          "description": "Whether to include verbose output from dcm2niix call. Options: true, false (default).",
+          "type": "boolean",
+          "default": false
+      },
       "decompress_dicoms": {
           "description": "Decompress DICOM files before conversion. This will perform decompression using gdcmconv and then perform the conversion using dcm2niix. Options: true, false (default).",
           "type": "boolean",
           "default": false
       },
       "filename": {
-          "description": "Output filename template. Options: %a=antenna (coil) number, %c=comments, %d=description, %e=echo number, %f=folder name, %i=ID of patient, %j=seriesInstanceUID, %k=studyInstanceUID, %m=manufacturer, %n=name of patient, %p=protocol, %s=series number, %t=time, %u=acquisition number, %v=vendor, %x=study ID, %z=sequence name. Can combine any of the options into a phrase (e.g., '%f_%p_%t_%s'). '%f' (default).",
+          "description": "Output filename template. Options: %a=antenna (coil) name, %b=basename, %c=comments, %d=series description, %e=echo number, %f=folder name, %i=ID of patient, %j=seriesInstanceUID, %k=studyInstanceUID, %m=manufacturer, %n=name of patient, %o=mediaObjectInstanceUID, %p=protocol, %r=instance number, %s=series number, %t=time, %u=acquisition number, %v=vendor, %x=study ID, %z=sequence name tag(0018,0024), %q sequence name tag(0018,1020). Defaults: dcm2niix tool `%f_%p_%t_%s` and dcm2niix Gear `%f`",
           "type": "string",
           "default": "%f"
       },
@@ -211,11 +216,6 @@
       },
       "text_notes_private": {
           "description": "Text notes including private patient details. Options: true, false (default).",
-          "type": "boolean",
-          "default": false
-      },
-      "verbose": {
-          "description": "Whether to include verbose output from dcm2niix call. Options: true, false (default).",
           "type": "boolean",
           "default": false
       }

--- a/run.py
+++ b/run.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Main script for dcm2niix gear."""
+# MAIN: cleanse and collate logic on ignore errors and empty image output scenarios
 
 import os
 

--- a/run.py
+++ b/run.py
@@ -29,14 +29,14 @@ def main(gear_context):
 
     # Nipype interface output from dcm2niix can be a string or list (desired)
     if output is not None:
-        nifti_files = output.outputs.converted_files
+        output_image_files = output.outputs.converted_files
 
-        if isinstance(nifti_files, str):
-            nifti_files = [nifti_files]
+        if isinstance(output_image_files, str):
+            output_image_files = [output_image_files]
     else:
-        nifti_files = None
+        output_image_files = None
 
-    if not isinstance(nifti_files, list):
+    if not isinstance(output_image_files, list):
         if not gear_context.config["ignore_errors"]:
             log.error("NIfTIs not produced from dcm2niix conversion. Exiting.")
             os.sys.exit(1)
@@ -48,21 +48,24 @@ def main(gear_context):
                 "you know what you are asking for. "
                 "Continuing."
             )
-            nifti_files = None
+            output_image_files = None
 
-    # Apply coil combined method
-    if gear_context.config["coil_combine"]:
-        dcm2niix_utils.coil_combine(nifti_files)
+    # NIfTI files are assumed to be expected for coil combined and pydeface
+    if not gear_context.config["output_nrrd"]:
 
-    # Run pydeface
-    if gear_context.config["pydeface"]:
-        gear_args = parse_config.generate_gear_args(gear_context, "pydeface")
-        pydeface_run.deface_multiple_niftis(nifti_files, **gear_args)
+        # Apply coil combined method
+        if gear_context.config["coil_combine"]:
+            dcm2niix_utils.coil_combine(output_image_files)
+
+        # Run pydeface
+        if gear_context.config["pydeface"]:
+            gear_args = parse_config.generate_gear_args(gear_context, "pydeface")
+            pydeface_run.deface_multiple_niftis(output_image_files, **gear_args)
 
     # Resolve gear outputs, including metadata capture
     gear_args = parse_config.generate_gear_args(gear_context, "resolve")
     resolve.setup(
-        nifti_files,
+        output_image_files,
         gear_context.work_dir,
         dcm2niix_input_dir,
         gear_context.output_dir,

--- a/tests/instance/assess_instance_runs.py
+++ b/tests/instance/assess_instance_runs.py
@@ -3,18 +3,18 @@ import datetime
 import flywheel
 import pandas as pd
 
-versions = ["1.0.0_1.0.20200331", "1.1.0_1.0.20201102_dev0"]
+versions = ["1.0.0_1.0.20200331", "1.1.0_1.0.20201102_dev1"]
 
 
 input_dir = "~/Documents/flywheel/gears/dcm2niix/tests/instance"
 date = str(datetime.date.today())
 
-previous = pd.read_csv(f"{input_dir}/dcm2niix_instance_runs_{version[0]}_{date}.csv")
-updated = pd.read_csv(f"{input_dir}/dcm2niix_instance_runs_{version[1]}_{date}.csv")
+previous = pd.read_csv(f"{input_dir}/dcm2niix_instance_runs_{versions[0]}_{date}.csv")
+updated = pd.read_csv(f"{input_dir}/dcm2niix_instance_runs_{versions[1]}_{date}.csv")
 
 # Remove where inputs, outputs, and job status are equivalent
 equivalent = previous.merge(
-    rewrite, how="inner", on=["inputs", "destination_id", "state", "outputs"]
+    updated, how="inner", on=["inputs", "destination_id", "state", "outputs"]
 )
 previous = previous.loc[~previous["job_id"].isin(equivalent["job_id_x"].to_list())]
 updated = updated.loc[~updated["job_id"].isin(equivalent["job_id_y"].to_list())]
@@ -27,7 +27,6 @@ compare = compare[
 
 
 fw = flywheel.Client()
-
 
 job_id = ""
 job_logs = fw.get_job_logs(job_id)

--- a/tests/instance/assess_instance_runs.py
+++ b/tests/instance/assess_instance_runs.py
@@ -1,25 +1,26 @@
+import datetime
+
 import flywheel
 import pandas as pd
 
+versions = ["1.0.0_1.0.20200331", "1.1.0_1.0.20201102_dev0"]
+
 
 input_dir = "~/Documents/flywheel/gears/dcm2niix/tests/instance"
+date = str(datetime.date.today())
 
-original = pd.read_csv(
-    f"{input_dir}/dcm2niix_instance_runs_0.9.0_1.0.20190902.rc2_2020-09-30.csv"
-)
-rewrite = pd.read_csv(
-    f"{input_dir}/dcm2niix_rewrite_test_1.0.0_1.0.20200331_2020-09-30.csv"
-)
+previous = pd.read_csv(f"{input_dir}/dcm2niix_instance_runs_{version[0]}_{date}.csv")
+updated = pd.read_csv(f"{input_dir}/dcm2niix_instance_runs_{version[1]}_{date}.csv")
 
 # Remove where inputs, outputs, and job status are equivalent
-equivalent = original.merge(
+equivalent = previous.merge(
     rewrite, how="inner", on=["inputs", "destination_id", "state", "outputs"]
 )
-original = original.loc[~original["job_id"].isin(equivalent["job_id_x"].to_list())]
-rewrite = rewrite.loc[~rewrite["job_id"].isin(equivalent["job_id_y"].to_list())]
+previous = previous.loc[~previous["job_id"].isin(equivalent["job_id_x"].to_list())]
+updated = updated.loc[~updated["job_id"].isin(equivalent["job_id_y"].to_list())]
 
 
-compare = original.merge(rewrite, how="left", on=["inputs", "destination_id"])
+compare = previous.merge(updated, how="left", on=["inputs", "destination_id"])
 compare = compare[
     ["job_id_x", "job_id_y", "state_x", "state_y", "outputs_x", "outputs_y"]
 ]

--- a/tests/instance/submit_instance_runs.py
+++ b/tests/instance/submit_instance_runs.py
@@ -1,6 +1,6 @@
 """Run two versions of the dcm2niix Gear on the same inputs and capture resulting job information."""
 
-versions = ["0.9.0_1.0.20190902.rc2", "1.0.0_1.0.20200331"]
+versions = ["1.0.0_1.0.20200331", "1.1.0_1.0.20201102_dev0"]
 output_dir = "~/Documents/flywheel/gears/dcm2niix/tests/instance"
 
 import time

--- a/tests/instance/submit_instance_runs.py
+++ b/tests/instance/submit_instance_runs.py
@@ -1,6 +1,6 @@
 """Run two versions of the dcm2niix Gear on the same inputs and capture resulting job information."""
 
-versions = ["1.0.0_1.0.20200331", "1.1.0_1.0.20201102_dev0"]
+versions = ["1.0.0_1.0.20200331", "1.1.0_1.0.20201102_dev1"]
 output_dir = "~/Documents/flywheel/gears/dcm2niix/tests/instance"
 
 import time

--- a/utils/parse_config.py
+++ b/utils/parse_config.py
@@ -92,7 +92,7 @@ def generate_gear_args(gear_context, FLAG):
             "philips_scaling": gear_context.config["philips_scaling"],
             "single_file_mode": gear_context.config["single_file_mode"],
             "text_notes_private": gear_context.config["text_notes_private"],
-            "verbose": gear_context.config["verbose"],
+            "verbose": gear_context.config["dcm2niix_verbose"],
         }
 
         # Anonymization cascade

--- a/utils/parse_config.py
+++ b/utils/parse_config.py
@@ -64,22 +64,35 @@ def generate_gear_args(gear_context, FLAG):
     elif FLAG == "dcm2niix":
 
         # Notice the explicit 'y' for bids_sidecar, in order to capture metadata; the
-        # user-defined config option setting wil be considered during gear resolve.
+        # user-defined config option setting wil be considered during the gear resolve stage.
+        filename = gear_context.config["filename"]
+        filename = filename.replace(" ", "_")
+
+        comment = gear_context.config["comment"]
+        if len(comment) > 24:
+            log.error(
+                f"The comment configuration option must be less than 25 characters. You have entered {len(comment)} characters. Please edit and resubmit Gear. Exiting."
+            )
+            os.sys.exit(1)
+
         gear_args = {
             "anonymize_bids": gear_context.config["anonymize_bids"],
             "bids_sidecar": "y",
+            "comment": comment,
             "compress_nifti": gear_context.config["compress_nifti"],
             "compression_level": gear_context.config["compression_level"],
             "convert_only_series": gear_context.config["convert_only_series"],
             "crop": gear_context.config["crop"],
-            "filename": gear_context.config["filename"],
+            "filename": filename,
             "ignore_derived": gear_context.config["ignore_derived"],
             "ignore_errors": gear_context.config["ignore_errors"],
             "lossless_scaling": gear_context.config["lossless_scaling"],
             "merge2d": gear_context.config["merge2d"],
+            "output_nrrd": gear_context.config["output_nrrd"],
             "philips_scaling": gear_context.config["philips_scaling"],
             "single_file_mode": gear_context.config["single_file_mode"],
             "text_notes_private": gear_context.config["text_notes_private"],
+            "verbose": gear_context.config["verbose"],
         }
 
         # Anonymization cascade
@@ -129,6 +142,7 @@ def generate_gear_args(gear_context, FLAG):
             "ignore_errors": gear_context.config["ignore_errors"],
             "retain_sidecar": True,
             "retain_nifti": True,
+            "output_nrrd": gear_context.config["output_nrrd"],
             "pydeface_intermediaries": False,
             "classification": None,
             "modality": None,
@@ -142,6 +156,9 @@ def generate_gear_args(gear_context, FLAG):
 
         if gear_context.config["pydeface_nocleanup"]:
             gear_args["pydeface_intermediaries"] = True
+
+        if gear_context.config["output_nrrd"]:
+            gear_args["retain_nifti"] = False
 
         try:
             classification = (

--- a/utils/resolve.py
+++ b/utils/resolve.py
@@ -1,4 +1,5 @@
-"""Function to resolve dcm2niix gear outputs."""
+"""Functions to resolve dcm2niix gear outputs."""
+# ENH: refactor script to make more explicit on output image formats and black compatible throughout, if possible.
 
 import glob
 import logging


### PR DESCRIPTION
ENH: Upgrade dcm2niix algorithm version to latest.

- The most applicable dcm2niix version upgrade includes fixes for BIDS RepetitionTimeExcitation and RepetitionTimeInversion tags (https://github.com/rordenlab/dcm2niix/issues/439)

ENH: Incorporate additional dcm2niix command options including NRRD format, comments, and verbose logging.
MAIN: Update instance tests accordingly.
DOC: Updates to README regarding metadata captured from this Gear.

Instance tests run on ss.ce using dcm2niix_rewrite_test collection as inputs.