### PR TITLE
Gear 715 tool error bypass json formatting

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "dcm2niix",
   "label": "dcm2niix: DICOM to NIfTI conversion (with PyDeface)",
   "description": "Implementation of Chris Rorden's dcm2niix tool for converting DICOM (or PAR/REC) to NIfTI (or NRRD), with an optional implementation of Poldrack Lab's PyDeface to remove facial structures from NIfTI.",
-  "version": "1.2.0_1.0.20201102",
+  "version": "1.2.1_1.0.20201102_dev1",
   "author": "Flywheel",
   "maintainer": "Flywheel <support@flywheel.io>",
   "url": "https://github.com/rordenlab/dcm2niix",
@@ -12,7 +12,7 @@
   "custom": {
        "gear-builder": {
            "category": "converter",
-           "image": "flywheel/dcm2niix:1.2.0_1.0.20201102"
+           "image": "flywheel/dcm2niix:1.2.1_1.0.20201102"
       },
       "flywheel": {
           "suite": "Conversion"

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "dcm2niix",
   "label": "dcm2niix: DICOM to NIfTI conversion (with PyDeface)",
   "description": "Implementation of Chris Rorden's dcm2niix tool for converting DICOM (or PAR/REC) to NIfTI (or NRRD), with an optional implementation of Poldrack Lab's PyDeface to remove facial structures from NIfTI.",
-  "version": "1.2.1_1.0.20201102_dev1",
+  "version": "1.2.1_1.0.20201102",
   "author": "Flywheel",
   "maintainer": "Flywheel <support@flywheel.io>",
   "url": "https://github.com/rordenlab/dcm2niix",

--- a/pydeface/pydeface_run.py
+++ b/pydeface/pydeface_run.py
@@ -74,19 +74,19 @@ def deface_single_nifti(
     command = ["pydeface"]
 
     command.append("--outfile")
-    command.append(infile)
+    command.append(str(infile))
     command.append("--force")
 
     command.append("--cost")
-    command.append(pydeface_cost)
+    command.append(str(pydeface_cost))
 
     if template:
         command.append("--template")
-        command.append(template)
+        command.append(str(template))
 
     if facemask:
         command.append("--facemask")
-        command.append(facemask)
+        command.append(str(facemask))
 
     if pydeface_nocleanup:
         command.append("--nocleanup")
@@ -94,7 +94,7 @@ def deface_single_nifti(
     if pydeface_verbose:
         command.append("--verbose")
 
-    command.append(infile)
+    command.append(str(infile))
     log_command = " ".join(command)
     log.info(f"Command to be executed: \n\n{log_command}\n")
 

--- a/tests/instance/assess_instance_runs.py
+++ b/tests/instance/assess_instance_runs.py
@@ -3,7 +3,7 @@ import datetime
 import flywheel
 import pandas as pd
 
-versions = ["1.0.0_1.0.20200331", "1.2.0_1.0.20201102_dev3"]
+versions = ["1.0.0_1.0.20200331", "1.2.1_1.0.20201102_dev1"]
 
 
 input_dir = "~/Documents/flywheel/gears/dcm2niix/tests/instance"

--- a/tests/instance/submit_instance_runs.py
+++ b/tests/instance/submit_instance_runs.py
@@ -1,6 +1,6 @@
 """Run two versions of the dcm2niix Gear on the same inputs and capture resulting job information."""
 
-versions = ["1.0.0_1.0.20200331", "1.2.0_1.0.20201102_dev3"]
+versions = ["1.0.0_1.0.20200331", "1.2.1_1.0.20201102_dev1"]
 output_dir = "~/Documents/flywheel/gears/dcm2niix/tests/instance"
 
 import time
@@ -14,7 +14,7 @@ fw = flywheel.Client()
 def main():
 
     # Find the collection
-    collection = fw.collections.find_one(f"label=dcm2niix_rewrite_test")
+    collection = fw.collections.find_one("label=dcm2niix_rewrite_test")
 
     # Find all the acquisitions in the collection
     acquisitions = fw.get_collection_acquisitions(collection.id)

--- a/tests/local/build_gear.sh
+++ b/tests/local/build_gear.sh
@@ -1,0 +1,30 @@
+# Development tag
+TAG=1.2.1_1.0.20201102_dev2
+LOCAL='no'
+
+# Make upload directory
+UPLOAD_DIR=${HOME}/gears/upload_zone
+mkdir -p ${UPLOAD_DIR}
+
+# Copy necessary files to upload directory
+cp Dockerfile ${UPLOAD_DIR}
+cp manifest.json ${UPLOAD_DIR}
+cp requirements.txt ${UPLOAD_DIR}
+cp run.py ${UPLOAD_DIR}
+cp -r dcm2niix/ ${UPLOAD_DIR}
+cp -r pydeface/ ${UPLOAD_DIR}
+cp -r utils/ ${UPLOAD_DIR}
+
+cd ${UPLOAD_DIR}
+echo ${PWD}
+
+# Build the docker image
+docker build -t flywheel/dcm2niix:${TAG} ./
+
+# Test gear locally
+if [ ${LOCAL} == 'yes' ]; then
+	fw gear local --dcm2niix_input ~/gears/dcm2niix/tests/assets/aliza_siemens_trio.zip
+fi
+
+# Finish 
+echo "Finished."

--- a/tests/local/defaults_with_modality_and_classification_set.json
+++ b/tests/local/defaults_with_modality_and_classification_set.json
@@ -1,0 +1,77 @@
+{
+ "config": {
+      "anonymize_bids": true,
+      "bids_sidecar": "n",
+      "coil_combine": false,
+      "comment": "",
+      "compress_images": "y",
+      "compression_level": 6,
+      "convert_only_series": "all",
+      "crop": false,
+      "dcm2niix_verbose": false,
+      "decompress_dicoms": false,
+      "filename": "%f",
+      "ignore_derived": false,
+      "ignore_errors": false,
+      "lossless_scaling": "n",
+      "merge2d": false,
+      "output_nrrd": false,
+      "philips_scaling": true,
+      "pydeface": false,
+      "pydeface_cost": "mutualinfo",
+      "pydeface_nocleanup": false,
+      "pydeface_verbose": false,
+      "remove_incomplete_volumes": false,
+      "single_file_mode": false,
+      "text_notes_private": false
+  },
+  "inputs": {
+      "dcm2niix_input": {
+            "base": "file",
+            "hierarchy": {
+                "id": "123abc",
+                "type": "acquisition"
+            },
+            "location": {
+                "name": "images.zip",
+                "path": "/flywheel/v0/input/scan_file/images.zip"
+            },
+            "object": {
+                "classification": {
+                    "Custom": [],
+                    "Intent": [
+                        "Structural"
+                    ],
+                    "Measurement": [
+                        "T1"
+                    ]
+                },
+                "info": {},
+                "measurements": [
+                    "Structural",
+                    "T1"
+                ],
+                "mimetype": "application/zip",
+                "modality": "MR",
+                "size": 1234,
+                "tags": [],
+                "type": "dicom"
+            }
+      },
+      "rec_file_input": {
+          "base": "file",
+          "location": {"path": "",
+                       "name": ""}
+      },
+      "pydeface_template": {
+          "base": "file",
+          "location": {"path": "",
+                       "name": ""}
+      },
+      "pydeface_facemask": {
+          "base": "file",
+          "location": {"path": "",
+                       "name": ""}
+      }
+  }
+}

--- a/tests/local/defaults_with_modality_set.json
+++ b/tests/local/defaults_with_modality_set.json
@@ -1,0 +1,68 @@
+{
+ "config": {
+      "anonymize_bids": true,
+      "bids_sidecar": "n",
+      "coil_combine": false,
+      "comment": "",
+      "compress_images": "y",
+      "compression_level": 6,
+      "convert_only_series": "all",
+      "crop": false,
+      "dcm2niix_verbose": false,
+      "decompress_dicoms": false,
+      "filename": "%f",
+      "ignore_derived": false,
+      "ignore_errors": false,
+      "lossless_scaling": "n",
+      "merge2d": false,
+      "output_nrrd": false,
+      "philips_scaling": true,
+      "pydeface": false,
+      "pydeface_cost": "mutualinfo",
+      "pydeface_nocleanup": false,
+      "pydeface_verbose": false,
+      "remove_incomplete_volumes": false,
+      "single_file_mode": false,
+      "text_notes_private": false
+  },
+  "inputs": {
+      "dcm2niix_input": {
+            "base": "file",
+            "hierarchy": {
+                "id": "123abc",
+                "type": "acquisition"
+            },
+            "location": {
+                "name": "images.zip",
+                "path": "/flywheel/v0/input/scan_file/images.zip"
+            },
+            "object": {
+                "classification": {
+                    "Custom": []
+                },
+                "info": {},
+                "measurements": [],
+                "mimetype": "application/zip",
+                "modality": "MR",
+                "size": 1234,
+                "tags": [],
+                "type": "dicom"
+            }
+      },
+      "rec_file_input": {
+          "base": "file",
+          "location": {"path": "",
+                       "name": ""}
+      },
+      "pydeface_template": {
+          "base": "file",
+          "location": {"path": "",
+                       "name": ""}
+      },
+      "pydeface_facemask": {
+          "base": "file",
+          "location": {"path": "",
+                       "name": ""}
+      }
+  }
+}

--- a/tests/local/defaults_without_modality_or_classification_set.json
+++ b/tests/local/defaults_without_modality_or_classification_set.json
@@ -1,0 +1,66 @@
+{
+ "config": {
+      "anonymize_bids": true,
+      "bids_sidecar": "n",
+      "coil_combine": false,
+      "comment": "",
+      "compress_images": "y",
+      "compression_level": 6,
+      "convert_only_series": "all",
+      "crop": false,
+      "dcm2niix_verbose": false,
+      "decompress_dicoms": false,
+      "filename": "%f",
+      "ignore_derived": false,
+      "ignore_errors": false,
+      "lossless_scaling": "n",
+      "merge2d": false,
+      "output_nrrd": false,
+      "philips_scaling": true,
+      "pydeface": false,
+      "pydeface_cost": "mutualinfo",
+      "pydeface_nocleanup": false,
+      "pydeface_verbose": false,
+      "remove_incomplete_volumes": false,
+      "single_file_mode": false,
+      "text_notes_private": false
+  },
+  "inputs": {
+      "dcm2niix_input": {
+            "base": "file",
+            "hierarchy": {
+                "id": "123abc",
+                "type": "acquisition"
+            },
+            "location": {
+                "name": "images.zip",
+                "path": "/flywheel/v0/input/scan_file/images.zip"
+            },
+            "object": {
+                "classification": {},
+                "info": {},
+                "measurements": [],
+                "mimetype": "application/zip",
+                "modality": null,
+                "size": 1234,
+                "tags": [],
+                "type": "dicom"
+            }
+      },
+      "rec_file_input": {
+          "base": "file",
+          "location": {"path": "",
+                       "name": ""}
+      },
+      "pydeface_template": {
+          "base": "file",
+          "location": {"path": "",
+                       "name": ""}
+      },
+      "pydeface_facemask": {
+          "base": "file",
+          "location": {"path": "",
+                       "name": ""}
+      }
+  }
+}

--- a/tests/local/fix_dcm_vols.py
+++ b/tests/local/fix_dcm_vols.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+
+# Call this script with the path to your dicom folder as argument
+# e.g., python fix_dcm_incompletevols.py dicom_folder
+# p.c.klink@gmail.com
+
+import os, sys, shutil, glob
+import pydicom, numpy
+
+if len(sys.argv) > 1:
+    dcmpath = sys.argv[1]
+
+    # get all dcm files
+    dcm_list = glob.glob(dcmpath + "/*.dcm")
+
+    # get the temporal position tag for all dcm files
+    print("Scanning " + dcmpath + " for dcm files...")
+    vol_num = []
+    for f in dcm_list:
+        dcm_info = pydicom.filereader.dcmread(f, stop_before_pixels=True)
+        vol_num.append(dcm_info.TemporalPositionIdentifier)
+
+    # how many slices in each volume
+    vol_list = []
+    for i in numpy.unique(vol_num):
+        vol_list.append(vol_num.count(i))
+
+    print("Number of slices in each volume")
+    print(vol_list)
+
+    # get the indexes of the slices belonging to the last (incomplete) volume
+    if vol_list[-1] != vol_list[0]:
+        del_dcm = [i for i, x in enumerate(vol_num) if x == numpy.max(vol_num)]
+        print("The following slice files will be taken out")
+        print(del_dcm)
+
+        if os.path.isdir(dcmpath + "/orphan_dcm") is False:
+            os.mkdir(dcmpath + "/orphan_dcm")
+            os.mkdir(dcmpath + "/corrected_dcm")
+
+        print("Moving " + str(len(del_dcm)) + " orphan dcm files to orphan_dcm")
+        for f in del_dcm:
+            shutil.move(
+                dcm_list[f], dcmpath + "/orphan_dcm/" + dcm_list[f].split("/")[-1]
+            )
+
+        print("Moving the rest of the dcm files to corrected_dcm")
+        for f in glob.glob(dcmpath + "/*.dcm"):
+            shutil.move(f, dcmpath + "/corrected_dcm/")
+    else:
+        print("All volumes are complete, will not mess with dcm files.")
+else:
+    print("No dicom-folder specified. Please re-run with path argument.")

--- a/utils/metadata.py
+++ b/utils/metadata.py
@@ -251,7 +251,7 @@ def capture(
                 if output_nrrd:
 
                     # NRRD
-                    if file_type in [".raw", ".nhdr", ".nrrd"]:
+                    if file_type in [".raw.gz", ".nhdr", ".nrrd"]:
                         filedata = create_file_metadata(
                             file, "nrrd", classification, metadata, modality
                         )

--- a/utils/metadata.py
+++ b/utils/metadata.py
@@ -19,7 +19,7 @@ def generate(
     output_sidecar_files,
     work_dir,
     dcm2niix_input_dir=None,
-    retain_sidecar=True,
+    retain_sidecar=False,
     retain_nifti=True,
     output_nrrd=False,
     pydeface_intermediaries=False,
@@ -221,26 +221,28 @@ def capture(
         # Data files
         for file in output_image_files:
 
-            if Path(file).stem == Path(sidecar).stem:
-
+            if Path(sidecar).stem in Path(file).stem:
+                
+                file_type = "".join(Path(file).suffixes)
+                
                 if retain_nifti:
 
                     # NIfTI
-                    if Path(file).suffix in [".nii.gz", ".nii"]:
+                    if file_type in [".nii.gz", ".nii"]:
                         filedata = create_file_metadata(
                             file, "nifti", classification, metadata, modality
                         )
                         capture_metadata.append(filedata)
 
                     # bval
-                    if Path(file).suffix in [".bval"]:
+                    if file_type in [".bval"]:
                         filedata = create_file_metadata(
                             file, "bval", classification, metadata, modality
                         )
                         capture_metadata.append(filedata)
 
                     # bvec
-                    if Path(file).suffix in [".bvec"]:
+                    if file_type in [".bvec"]:
                         filedata = create_file_metadata(
                             file, "bvec", classification, metadata, modality
                         )
@@ -249,7 +251,7 @@ def capture(
                 if output_nrrd:
 
                     # NRRD
-                    if Path(file).suffix in [".raw", ".nhdr", ".nrrd"]:
+                    if file_type in [".raw", ".nhdr", ".nrrd"]:
                         filedata = create_file_metadata(
                             file, "nrrd", classification, metadata, modality
                         )

--- a/utils/metadata.py
+++ b/utils/metadata.py
@@ -222,9 +222,9 @@ def capture(
         for file in output_image_files:
 
             if Path(sidecar).stem in Path(file).stem:
-                
+
                 file_type = "".join(Path(file).suffixes)
-                
+
                 if retain_nifti:
 
                     # NIfTI

--- a/utils/parse_config.py
+++ b/utils/parse_config.py
@@ -18,7 +18,7 @@ def generate_gear_args(gear_context, FLAG):
         infile = gear_context.get_input_path("dcm2niix_input")
         try:
             with open(infile, "r") as f:
-                log.debug(f"{infile} opened from dcm2niix_input.")
+                log.debug(f"{f} opened from dcm2niix_input.")
 
         except FileNotFoundError:
             # Path separation in filename may cause downloaded filename to be altered
@@ -32,7 +32,7 @@ def generate_gear_args(gear_context, FLAG):
                 infile = f"/flywheel/v0/input/dcm2niix_input/{filename.split('/')[-1]}"
 
                 try:
-                    with open(infile, "r") as f:
+                    with open(infile, "r"):
                         log.debug(
                             f"{infile} opened from path separated dcm2niix_input."
                         )

--- a/utils/resolve.py
+++ b/utils/resolve.py
@@ -1,10 +1,9 @@
 """Functions to resolve dcm2niix gear outputs."""
 
-import glob
 import logging
 import os
-import re
 import shutil
+from pathlib import Path
 
 from utils import metadata
 
@@ -14,6 +13,7 @@ log = logging.getLogger(__name__)
 
 def setup(
     output_image_files,
+    output_sidecar_files,
     work_dir,
     dcm2niix_input_dir,
     output_dir,
@@ -28,9 +28,12 @@ def setup(
     """Orchestrate resolution of gear, including metadata capture and file retention.
 
     Args:
-        output_image_files (list): The absolute paths to gear image files to resolve.
+        output_image_files (list): The absolute paths to converted image files to resolve.
             Typically these are NIfTI files, but can be the two files constituting the
-            NRRD format (i.e., ".raw" and ".nhdr").
+            NRRD format (i.e., ".raw" and ".nhdr") or the NRRD format (i.e., ".nrrd").
+            Also contains ".bvals" and ".bvecs", if applicable.
+        output_sidecar_files (list): The absolute paths to the sidecar files to be
+            used as metadata on all files in the output_image_files input list.
         work_dir (str): The absolute path to the output directory of dcm2niix and where
             the metadata file generated is written to.
         dcm2niix_input_dir (str): The absolute path to the input directory to dcm2niix.
@@ -49,16 +52,14 @@ def setup(
     """
     # Ignoring errors configuration option; move all files from work_dir to output_dir
     if ignore_errors is True:
-        log.warning(
-            "Expert Option (ignore_errors). "
-            "We trust that since you have selected this option "
-            "you know what you are asking for. "
-            "Continuing."
-        )
+        log.warning("Applying Expert Option (ignore_errors).")
+
         if output_image_files is not None:
+
             # Capture metadata
             metadata_file = metadata.generate(
                 output_image_files,
+                output_sidecar_files,
                 work_dir,
                 dcm2niix_input_dir,
                 retain_sidecar=True,
@@ -69,10 +70,11 @@ def setup(
                 modality=modality,
             )
 
-        work_dir_contents = glob.glob(work_dir + "/*")
+        work_dir_contents = os.listdir(work_dir)
         for item in work_dir_contents:
-            if not os.path.isdir(item):
-                shutil.move(item, output_dir)
+            item_path = os.path.join(work_dir, item)
+            if not os.path.isdir(item_path):
+                shutil.move(item_path, output_dir)
                 log.info(f"Moving {item} to output directory for upload to Flywheel.")
 
     else:
@@ -80,6 +82,7 @@ def setup(
         # Capture metadata
         metadata_file = metadata.generate(
             output_image_files,
+            output_sidecar_files,
             work_dir,
             dcm2niix_input_dir,
             retain_sidecar=retain_sidecar,
@@ -93,6 +96,7 @@ def setup(
         # Retain gear outputs
         retain_gear_outputs(
             output_image_files,
+            output_sidecar_files,
             metadata_file,
             work_dir,
             output_dir,
@@ -105,6 +109,7 @@ def setup(
 
 def retain_gear_outputs(
     output_image_files,
+    output_sidecar_files,
     metadata_file,
     work_dir,
     output_dir,
@@ -116,9 +121,12 @@ def retain_gear_outputs(
     """Move selected gear outputs to the output directory.
 
     Args:
-        output_image_files (list): The absolute paths to gear image files to resolve.
+        output_image_files (list): The absolute paths to converted image files to resolve.
             Typically these are NIfTI files, but can be the two files constituting the
-            NRRD format (i.e., ".raw" and ".nhdr").
+            NRRD format (i.e., ".raw" and ".nhdr") or the NRRD format (i.e., ".nrrd").
+            Also contains ".bvals" and ".bvecs", if applicable.
+        output_sidecar_files (list): The absolute paths to the sidecar files to be
+            used as metadata on all files in the output_image_files input list.
         metadata_file (str): The absolute path to the metadata file.
         work_dir (str): The absolute path to the output directory of dcm2niix and
             where the generated metadata file is.
@@ -145,88 +153,44 @@ def retain_gear_outputs(
         )
         os.sys.exit(1)
 
-    # fmt: off
-
-    for file in output_image_files:
+    for sidecar in output_sidecar_files:
 
         # Move bids json sidecar file, if indicated
-        # If NRRD format, two files per sidecar - move sidecar once
-        if retain_sidecar and not file.endswith(".nhdr"):
-            bids_sidecar = os.path.join(
-                                        work_dir, re.sub(
-                                                         r"(\.nii\.gz|\.nii|.nhdr|\.raw\.gz|\.nrrd)",
-                                                         ".json",
-                                                         os.path.basename(file))
-            )
+        if retain_sidecar:
+            shutil.move(sidecar, output_dir)
+            log.info(f"Moving {Path(sidecar).stem} to output directory.")
 
-            shutil.move(bids_sidecar, output_dir)
-            log.info(f"Moving {bids_sidecar} to output directory.")
+        # Move data files, if indicated
+        for file in output_image_files:
 
-        # Move niftis and associated files (.bval, .bvec, .mat), if indicated
-        if retain_nifti and not output_nrrd:
+            if Path(file).stem == Path(sidecar).stem:
 
-            # Move bval file, if exists
-            bval = os.path.join(
-                                work_dir, re.sub(
-                                                 r"(\.nii\.gz|\.nii)",
-                                                 ".bval",
-                                                 os.path.basename(file))
-            )
+                if retain_nifti:
+                    if Path(file).suffix in [".nii.gz", ".nii", ".bval", ".bvec"]:
+                        log.info(f"Moving {Path(file).stem} to output directory.")
+                        shutil.move(file, output_dir)
 
-            if os.path.isfile(bval):
-                shutil.move(bval, output_dir)
-                log.info(f"Moving {bval} to output directory.")
+                if output_nrrd:
+                    if Path(file).suffix in [".raw", ".nhdr", ".nrrd"]:
+                        log.info(f"Moving {Path(file).stem} to output directory.")
+                        shutil.move(file, output_dir)
 
-            # Move bvec file, if exists
-            bvec = os.path.join(
-                                work_dir, re.sub(
-                                                 r"(\.nii\.gz|\.nii)",
-                                                 ".bvec",
-                                                 os.path.basename(file))
-            )
+        # PyDeface files
+        if pydeface_intermediaries:
 
-            if os.path.isfile(bvec):
-                shutil.move(bvec, output_dir)
-                log.info(f"Moving {bvec} to output directory.")
+            # The output mask of PyDeface is a compressed nifti, even if .nii input
+            file = os.path.join(work_dir, f"{Path(sidecar).stem}_pydeface_mask.nii.gz")
+            if os.path.isfile(file):
+                log.info(f"Moving {file} to output directory.")
+                shutil.move(file, output_dir)
 
-            # Move pydeface intermediary files, if exists
-            if pydeface_intermediaries:
-
-                # The output mask of PyDeface is a compressed nifti, even if .nii input
-                pydeface_mask = os.path.join(
-                                             work_dir, re.sub(
-                                                              r"(\.nii\.gz|\.nii)",
-                                                              "_pydeface_mask.nii.gz",
-                                                              os.path.basename(file))
-                )
-
-                if os.path.isfile(pydeface_mask):
-                    shutil.move(pydeface_mask, output_dir)
-                    log.info(f"Moving {pydeface_mask} to output directory.")
-
-                pydeface_matlab = os.path.join(
-                                               work_dir, re.sub(
-                                                                r"(\.nii\.gz|\.nii)",
-                                                                "_pydeface.mat",
-                                                                os.path.basename(file))
-                )
-
-                if os.path.isfile(pydeface_matlab):
-                    shutil.move(pydeface_matlab, output_dir)
-                    log.info(f"Moving {pydeface_matlab} to output directory.")
-
-            # Move nifti file
-            shutil.move(file, output_dir)
-            log.info(f"Moving {file} to output directory.")
-
-        # Move nrrd files
-        if output_nrrd and not retain_nifti:
-            shutil.move(file, output_dir)
-            log.info(f"Moving {file} to output directory.")
+            file = os.path.join(work_dir, f"{Path(sidecar).stem}_pydeface.mat")
+            if os.path.isfile(file):
+                log.info(f"Moving {file} to output directory.")
+                shutil.move(file, output_dir)
 
     # Move metadata file
     shutil.move(metadata_file, output_dir)
     log.info(f"Moving {metadata_file} to output directory.")
 
-    # fmt: on
     log.info("Gear outputs resolved.")

--- a/utils/resolve.py
+++ b/utils/resolve.py
@@ -18,7 +18,7 @@ def setup(
     dcm2niix_input_dir,
     output_dir,
     ignore_errors=False,
-    retain_sidecar=True,
+    retain_sidecar=False,
     retain_nifti=True,
     output_nrrd=False,
     pydeface_intermediaries=False,
@@ -158,21 +158,23 @@ def retain_gear_outputs(
         # Move bids json sidecar file, if indicated
         if retain_sidecar:
             shutil.move(sidecar, output_dir)
-            log.info(f"Moving {Path(sidecar).stem} to output directory.")
+            log.info(f"Moving {sidecar} to output directory.")
 
         # Move data files, if indicated
         for file in output_image_files:
 
-            if Path(file).stem == Path(sidecar).stem:
+            if Path(sidecar).stem in Path(file).stem:
 
+                file_type = "".join(Path(file).suffixes)
+                
                 if retain_nifti:
-                    if Path(file).suffix in [".nii.gz", ".nii", ".bval", ".bvec"]:
-                        log.info(f"Moving {Path(file).stem} to output directory.")
+                    if file_type in [".nii.gz", ".nii", ".bval", ".bvec"]:
+                        log.info(f"Moving {file} to output directory.")
                         shutil.move(file, output_dir)
 
                 if output_nrrd:
-                    if Path(file).suffix in [".raw", ".nhdr", ".nrrd"]:
-                        log.info(f"Moving {Path(file).stem} to output directory.")
+                    if file_type in [".raw", ".nhdr", ".nrrd"]:
+                        log.info(f"Moving {file} to output directory.")
                         shutil.move(file, output_dir)
 
         # PyDeface files

--- a/utils/resolve.py
+++ b/utils/resolve.py
@@ -166,7 +166,7 @@ def retain_gear_outputs(
             if Path(sidecar).stem in Path(file).stem:
 
                 file_type = "".join(Path(file).suffixes)
-                
+
                 if retain_nifti:
                     if file_type in [".nii.gz", ".nii", ".bval", ".bvec"]:
                         log.info(f"Moving {file} to output directory.")

--- a/utils/resolve.py
+++ b/utils/resolve.py
@@ -173,7 +173,7 @@ def retain_gear_outputs(
                         shutil.move(file, output_dir)
 
                 if output_nrrd:
-                    if file_type in [".raw", ".nhdr", ".nrrd"]:
+                    if file_type in [".raw.gz", ".nhdr", ".nrrd"]:
                         log.info(f"Moving {file} to output directory.")
                         shutil.move(file, output_dir)
 


### PR DESCRIPTION
Patch version.

BUG: TypeError: Object of type 'bytes' is not JSON serializable. Occurs when the JSON sidecar produced by the dcm2niix tool contains bytes, which need to be decoded.

MAIN: Refactor script to use JSON sidecar as leading the metadata application, instead of based on image output files.

FIX: Resolve minor path issues.

ENH: Add local tests directory with default config files for testing; in addition to a gear building script.