### PR TITLE
MAIN: Adjust check for sidecar to output image match.

### DIFF
--- a/dcm2niix_gear/utils/metadata.py
+++ b/dcm2niix_gear/utils/metadata.py
@@ -230,7 +230,7 @@ def capture(
                 continue
             # Get "root" and what's "left" over after splitting of "root" name
             #   from sidecar
-            substr = _, left
+            _, left = substr
 
             if retain_nifti:
 

--- a/dcm2niix_gear/utils/metadata.py
+++ b/dcm2niix_gear/utils/metadata.py
@@ -219,43 +219,50 @@ def capture(
             capture_metadata.append(filedata)
 
         # Data files
+        # Split sidecar into the "root" name by removing .json suffix
+        stem = sidecar.split('.json')[0]
         for file in output_image_files:
+            # Split image name by "root" name from sidecar
+            substr = file.split(stem)
+            # If the "root" name of sidecar is not a substring of image file
+            #   We don't care about this image file.
+            if len(substr) < 2:
+                continue
+            # Get "root" and what's "left" over after splitting of "root" name
+            #   from sidecar
+            substr = _, left
 
-            if Path(sidecar).stem in Path(file).stem:
+            if retain_nifti:
 
-                file_type = "".join(Path(file).suffixes)
+                # NIfTI
+                if left in [".nii.gz", ".nii"]:
+                    filedata = create_file_metadata(
+                        file, "nifti", classification, metadata, modality
+                    )
+                    capture_metadata.append(filedata)
 
-                if retain_nifti:
+                # bval
+                if left in [".bval"]:
+                    filedata = create_file_metadata(
+                        file, "bval", classification, metadata, modality
+                    )
+                    capture_metadata.append(filedata)
 
-                    # NIfTI
-                    if file_type in [".nii.gz", ".nii"]:
-                        filedata = create_file_metadata(
-                            file, "nifti", classification, metadata, modality
-                        )
-                        capture_metadata.append(filedata)
+                # bvec
+                if left in [".bvec"]:
+                    filedata = create_file_metadata(
+                        file, "bvec", classification, metadata, modality
+                    )
+                    capture_metadata.append(filedata)
 
-                    # bval
-                    if file_type in [".bval"]:
-                        filedata = create_file_metadata(
-                            file, "bval", classification, metadata, modality
-                        )
-                        capture_metadata.append(filedata)
+            if output_nrrd:
 
-                    # bvec
-                    if file_type in [".bvec"]:
-                        filedata = create_file_metadata(
-                            file, "bvec", classification, metadata, modality
-                        )
-                        capture_metadata.append(filedata)
-
-                if output_nrrd:
-
-                    # NRRD
-                    if file_type in [".raw.gz", ".nhdr", ".nrrd"]:
-                        filedata = create_file_metadata(
-                            file, "nrrd", classification, metadata, modality
-                        )
-                        capture_metadata.append(filedata)
+                # NRRD
+                if left in [".raw.gz", ".nhdr", ".nrrd"]:
+                    filedata = create_file_metadata(
+                        file, "nrrd", classification, metadata, modality
+                    )
+                    capture_metadata.append(filedata)
 
         # PyDeface files
         if pydeface_intermediaries:

--- a/dcm2niix_gear/utils/resolve.py
+++ b/dcm2niix_gear/utils/resolve.py
@@ -162,20 +162,31 @@ def retain_gear_outputs(
 
         # Move data files, if indicated
         for file in output_image_files:
+            # Split sidecar into the "root" name by removing .json suffix
+            stem = sidecar.split('.json')[0]
+            # Split image name by "root" name from sidecar
+            substr = file.split(stem)
+            # If the "root" name of sidecar is not a substring of image file
+            #   We don't care about this image file.
+            if len(substr) < 2:
+                continue
+            # Get "root" and what's "left" over after splitting of "root" name
+            #   from sidecar
+            substr = root, left
 
-            if Path(sidecar).stem in Path(file).stem:
+            if retain_nifti:
+                # If "left" over is simply the extension, this image matches
+                #   the current sidecar, move to output.
+                if left in [".nii.gz", ".nii", ".bval", ".bvec"]:
+                    log.info(f"Moving {file} to output directory.")
+                    shutil.move(file, output_dir)
 
-                file_type = "".join(Path(file).suffixes)
-
-                if retain_nifti:
-                    if file_type in [".nii.gz", ".nii", ".bval", ".bvec"]:
-                        log.info(f"Moving {file} to output directory.")
-                        shutil.move(file, output_dir)
-
-                if output_nrrd:
-                    if file_type in [".raw.gz", ".nhdr", ".nrrd"]:
-                        log.info(f"Moving {file} to output directory.")
-                        shutil.move(file, output_dir)
+            if output_nrrd:
+                # If "left" over is simply the extension, this image matches
+                #   the current sidecar, move to output.
+                if left in [".raw.gz", ".nhdr", ".nrrd"]:
+                    log.info(f"Moving {file} to output directory.")
+                    shutil.move(file, output_dir)
 
         # PyDeface files
         if pydeface_intermediaries:

--- a/dcm2niix_gear/utils/resolve.py
+++ b/dcm2niix_gear/utils/resolve.py
@@ -161,9 +161,9 @@ def retain_gear_outputs(
             log.info(f"Moving {sidecar} to output directory.")
 
         # Move data files, if indicated
+        # Split sidecar into the "root" name by removing .json suffix
+        stem = sidecar.split('.json')[0]
         for file in output_image_files:
-            # Split sidecar into the "root" name by removing .json suffix
-            stem = sidecar.split('.json')[0]
             # Split image name by "root" name from sidecar
             substr = file.split(stem)
             # If the "root" name of sidecar is not a substring of image file
@@ -172,7 +172,7 @@ def retain_gear_outputs(
                 continue
             # Get "root" and what's "left" over after splitting of "root" name
             #   from sidecar
-            substr = root, left
+            substr = _, left
 
             if retain_nifti:
                 # If "left" over is simply the extension, this image matches

--- a/dcm2niix_gear/utils/resolve.py
+++ b/dcm2niix_gear/utils/resolve.py
@@ -172,7 +172,7 @@ def retain_gear_outputs(
                 continue
             # Get "root" and what's "left" over after splitting of "root" name
             #   from sidecar
-            substr = _, left
+            _, left = substr
 
             if retain_nifti:
                 # If "left" over is simply the extension, this image matches


### PR DESCRIPTION
Current implementation moves every output image that contains a _substring_ of each sidecar stem.

Since dcm2niix often outputs a "base" image plus images with suffixes, such as:

```bash
img1.nii.gz / img1.json
img1_real.nii.gz / img1_real.json
img1_ph.nii.gz / img1_ph.json
img1_imaginary.nii.gz / img1_imaginary.json
```
The sidecar `img1.json` has the stem `img1` which is a substring of every output.  Therefore it will try to double copy each output.

This fix adjusts moving output images by checking the "leftover" after the substring.  If that leftover is just a file suffix we expect, that image matches the sidecar.

i.e.:
```python
>>> sidecar = 'img1.json'
>>> root = sidecar.split('.json')[0]
>>> root
'img1'
>>> 'img1.nii.gz'.split(root)
>>> ['','.nii.gz'] # Matches file extension so this image matches and will be moved.
>>> 'img1_real.nii.gz'.split(root)
>>> ['','_real.nii.gz'] # Does not match file extension, so this image doesn't match and won't be moved
```
