### PR TITLE
Accomodate substr repeats to copy files

### DIFF
--- a/dcm2niix_gear/utils/resolve.py
+++ b/dcm2niix_gear/utils/resolve.py
@@ -179,7 +179,7 @@ def retain_gear_outputs(
                 # If "left" over is simply the extension, this image matches
                 #   the current sidecar, move to output. If an underscore is in "left", then
                 # there is likely a longer string filename that will match a specific sidecar
-                # in a future loop.
+                # in a future loop. `and left.startswith('.') may be equally as useful
                 if (left in [".nii.gz", ".nii", ".bval", ".bvec"]) and (not "_" in left):
                     log.info(f"Moving {file} to output directory.")
                     shutil.move(file, output_dir)

--- a/dcm2niix_gear/utils/resolve.py
+++ b/dcm2niix_gear/utils/resolve.py
@@ -162,6 +162,7 @@ def retain_gear_outputs(
 
         # Move data files, if indicated
         # Split sidecar into the "root" name by removing .json suffix
+        # Watch out for naming conflicts with shared stems (like stem_real.nii.gz or stem_imaginary.nii.gz)
         stem = sidecar.split('.json')[0]
         for file in output_image_files:
             # Split image name by "root" name from sidecar
@@ -176,8 +177,10 @@ def retain_gear_outputs(
 
             if retain_nifti:
                 # If "left" over is simply the extension, this image matches
-                #   the current sidecar, move to output.
-                if left in [".nii.gz", ".nii", ".bval", ".bvec"]:
+                #   the current sidecar, move to output. If an underscore is in "left", then
+                # there is likely a longer string filename that will match a specific sidecar
+                # in a future loop.
+                if (left in [".nii.gz", ".nii", ".bval", ".bvec"]) and (not "_" in left):
                     log.info(f"Moving {file} to output directory.")
                     shutil.move(file, output_dir)
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "dcm2niix",
   "label": "dcm2niix: DICOM to NIfTI conversion (with PyDeface)",
   "description": "Implementation of Chris Rorden's dcm2niix tool for converting DICOM (or PAR/REC) to NIfTI (or NRRD), with an optional implementation of Poldrack Lab's PyDeface to remove facial structures from NIfTI.",
-  "version": "1.3.2a_1.0.20201102",
+  "version": "1.3.2_1.0.20201102",
   "author": "Flywheel",
   "maintainer": "Flywheel <support@flywheel.io>",
   "url": "https://github.com/rordenlab/dcm2niix",
@@ -12,7 +12,7 @@
   "custom": {
        "gear-builder": {
            "category": "converter",
-           "image": "flywheel/dcm2niix:1.3.2a_1.0.20201102"
+           "image": "flywheel/dcm2niix:1.3.2_1.0.20201102"
       },
       "flywheel": {
           "suite": "Conversion"

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "dcm2niix",
   "label": "dcm2niix: DICOM to NIfTI conversion (with PyDeface)",
   "description": "Implementation of Chris Rorden's dcm2niix tool for converting DICOM (or PAR/REC) to NIfTI (or NRRD), with an optional implementation of Poldrack Lab's PyDeface to remove facial structures from NIfTI.",
-  "version": "1.3.1_1.0.20201102",
+  "version": "1.3.2_1.0.20201102",
   "author": "Flywheel",
   "maintainer": "Flywheel <support@flywheel.io>",
   "url": "https://github.com/rordenlab/dcm2niix",
@@ -12,7 +12,7 @@
   "custom": {
        "gear-builder": {
            "category": "converter",
-           "image": "flywheel/dcm2niix:1.3.1_1.0.20201102"
+           "image": "flywheel/dcm2niix:1.3.2_1.0.20201102"
       },
       "flywheel": {
           "suite": "Conversion"

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "dcm2niix",
   "label": "dcm2niix: DICOM to NIfTI conversion (with PyDeface)",
   "description": "Implementation of Chris Rorden's dcm2niix tool for converting DICOM (or PAR/REC) to NIfTI (or NRRD), with an optional implementation of Poldrack Lab's PyDeface to remove facial structures from NIfTI.",
-  "version": "1.3.2_1.0.20201102",
+  "version": "1.3.2a_1.0.20201102",
   "author": "Flywheel",
   "maintainer": "Flywheel <support@flywheel.io>",
   "url": "https://github.com/rordenlab/dcm2niix",
@@ -12,7 +12,7 @@
   "custom": {
        "gear-builder": {
            "category": "converter",
-           "image": "flywheel/dcm2niix:1.3.2_1.0.20201102"
+           "image": "flywheel/dcm2niix:1.3.2a_1.0.20201102"
       },
       "flywheel": {
           "suite": "Conversion"


### PR DESCRIPTION
_real, _imaginary, etc. were causing an issue with copying the converted nii.gz's

- stem derived from json was shortest substr first, which lead to attempts to recopy files over a loop in resolve.py
- Solved by disregarding a matching, longer filename with the substr in it in favor of copying the file when the name matched the stem.

Successful run produced the individual _e1* and _e2* files here:
https://rollout.ce.flywheel.io/#/projects/60b00610097ee44ff3bea44b/sessions/612560d63e7428283d9f24ee?tab=provenance